### PR TITLE
New parameter 'javaModules' adds Java 9+ modules via '--module-path'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   </description>
   <inceptionYear>2018</inceptionYear>
   <properties>
-    <aspectjVersion>1.9.5</aspectjVersion>
+    <aspectjVersion>1.9.7.BUILD-SNAPSHOT</aspectjVersion>
     <mavenVersion>3.0.5</mavenVersion>
     <doxiaVersion>1.8</doxiaVersion>
     <mojo.java.target>1.8</mojo.java.target> <!-- aspectJ > 1.8.13 is JDK 1.8 minimum -->
@@ -109,6 +109,9 @@
       <name>Nicholas Wong</name>
       <email>nickwongdev@gmail.com</email>
       <timezone>America/LosAngeles</timezone>
+    </contributor>
+    <contributor>
+      <name>Alexander Kriegisch</name>
     </contributor>
   </contributors>
 

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -613,6 +613,10 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
         addModulesArgument("-aspectpath", ajcOptions, aspectLibraries, getAdditionalAspectPaths(),
                 "an aspect library");
 
+        // Add Java 9+ modules needed for compilation
+        addModulesArgument("--module-path", ajcOptions, javaModules, null,
+                "Java module");
+
         // Add xmlConfigured option and argument
         if (null != xmlConfigured) {
             ajcOptions.add("-xmlConfigured");

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -189,25 +189,25 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     protected boolean XhasMember;
 
     /**
-     * Specify classfile target setting (1.1 to 1.8) default is 1.2
+     * Specify bytecode target setting (1.3 to 1.9, 10 to 16). See 'complianceLevel' for details. 
      *
+     * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
     @Parameter( defaultValue = "${project.build.java.target}" )
     protected String target;
 
     /**
-     * Toggle assertions (1.3, 1.4, 1.5, 1.6, 1.7 or 1.8 - default is 1.4). When using -source 1.3, an assert()
-     * statement valid under Java 1.4 will result in a compiler error. When using -source 1.4, treat assert
-     * as a keyword and implement assertions according to the 1.4 language spec. When using -source 1.5 or higher, Java
-     * 5 language features are permitted. With --source 1.7 or higher Java 7 features are supported.
+     * Specify source code language level (1.3 to 1.9, 10 to 16). See 'complianceLevel' for details. 
      *
+     * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
     @Parameter( defaultValue = "${mojo.java.target}" )
     protected String source;
 
     /**
-     * Specify compiler compliance setting.
-     * Defaults to 1.4, with permitted values ("1.3", "1.4", "1.5", "1.6" and "1.7", "1.8").
+     * Specify compiler compliance setting (same as setting 'source' and 'target' to the same level).
+     * Permitted values: 1.3, 1.4, 1.5, 5, 5.0, 1.6, 6, 6.0, 1.7, 7, 7.0, 1.8, 8, 8.0,
+     * 1.9, 9, 9.0, 10, 10.0, 11, 11.0, 12, 12.0, 13, 13.0, 14, 14.0, 15, 15.0, 16, 16.0.
      *
      * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
@@ -406,6 +406,18 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
      */
     @Parameter( defaultValue = "false" )
     protected boolean forceAjcCompile;
+
+    /**
+     * Activates compiler preview features (e.g. sealed classes in Java 16) when used with a suitable JDK version
+     *
+     * @since 1.12.7
+     */
+    // TODO:
+    //   Create tickets for at least Eclipse IDE and IntelliJ IDEA to recognise this switch and import it as a compiler
+    //   and possibly runtime setting. As for AJDT, maybe we have to implement it ourselves, but actually I found no
+    //   references to the Maven module there, so I guess the import is implemented somewhere else.
+    @Parameter( defaultValue = "false" )
+    protected boolean enablePreview;
 
     /**
      * Holder for ajc compiler options
@@ -873,13 +885,23 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     }
 
     public void setTarget(String target) {
-        ajcOptions.add("-target");
-        ajcOptions.add(target);
+        if (AjcHelper.isValidComplianceLevel(target)) {
+            ajcOptions.add("-target");
+            ajcOptions.add(target);
+        }
     }
 
     public void setSource(String source) {
-        ajcOptions.add("-source");
-        ajcOptions.add(source);
+        if (AjcHelper.isValidComplianceLevel(source)) {
+            ajcOptions.add("-source");
+            ajcOptions.add(source);
+        }
+    }
+
+    public void setEnablePreview(boolean enablePreview) {
+        if (enablePreview) {
+            ajcOptions.add("--enable-preview");
+        }
     }
 
     public void setVerbose(boolean verbose) {

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcMojo.java
@@ -71,6 +71,15 @@ public abstract class AbstractAjcMojo extends AbstractMojo
     protected String[] weaveDirectories;
 
     /**
+     * Java 9+ modules to build the module path from.
+     * Corresponds to <code>ajc --module-path</code> option.
+     *
+     * @since 1.12.7
+     */
+    @Parameter
+    protected Module[] javaModules;
+
+    /**
      * Weave binary aspects from the jars.
      * The aspects should have been output by the same version of the compiler.
      * The modules must also be dependencies of the project.

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -62,8 +62,23 @@ public class AjcHelper
     /**
      * List holding all accepted values for the {@code complianceLevel} parameter.
      */
-    public static final List<String> ACCEPTED_COMPLIANCE_LEVEL_VALUES =
-            Arrays.asList("1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13");
+    public static final List<String> ACCEPTED_COMPLIANCE_LEVEL_VALUES = Arrays.asList(
+      // TODO: update from AJC (AspectJ Compiler) regularly, which in turn extends ECJ (Eclipse Java Compiler)
+      "1.3",
+      "1.4",
+      "1.5", "5", "5.0",
+      "1.6", "6", "6.0",
+      "1.7", "7", "7.0",
+      "1.8", "8", "8.0",
+      "1.9", "9", "9.0",
+      "10", "10.0",
+      "11", "11.0",
+      "12", "12.0",
+      "13", "13.0",
+      "14", "14.0",
+      "15", "15.0",
+      "16", "16.0"
+    );
 
     /**
      * Checks if the given complianceLevel value is valid.

--- a/src/test/java/org/codehaus/mojo/aspectj/AbstractAjcCompilerTest.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/AbstractAjcCompilerTest.java
@@ -326,7 +326,89 @@ public class AbstractAjcCompilerTest
         assertTrue( weavePath.indexOf( mod1Artifact ) != -1 );
         assertTrue( weavePath.indexOf( mod2Artifact ) != -1 );
     }
-    
+
+    /**
+     * Verifies that if not stated no --module-path or -p argument should
+     * be found in the ajc arguments
+     * {@link AbstractAjcCompiler#execute()}
+     *
+     * @throws Exception
+     */
+    public void testGetAjcArguments_noModulePath()
+        throws Exception
+    {
+        ajcCompMojo.assembleArguments();
+        List args = ajcCompMojo.ajcOptions;
+        assertFalse( args.contains( "--module-path" ) );
+        assertFalse( args.contains( "-p" ) );
+    }
+
+    /**
+     * Tests that the compiler fails as it should if told to weave a module artifact not listed in the project
+     * dependencies.
+     *
+     * @throws Exception
+     */
+    public void testGetAjcArguments_moduleArtifactsNotProjectDependecy()
+    {
+        Module module1 = new Module();
+        String mod1Group = "dill.group";
+        module1.setGroupId( mod1Group );
+        String mod1Artifact = "dall.artifact";
+        module1.setArtifactId( mod1Artifact );
+        try
+        {
+            ajcCompMojo.javaModules = new Module[1];
+            ajcCompMojo.javaModules[0] = module1;
+            ajcCompMojo.assembleArguments();
+            fail( "Should fail quite miserably" );
+        }
+        catch ( MojoExecutionException e )
+        {
+            // good thing
+        }
+    }
+
+    /**
+     * Tests that Java 9+ module path works as expected if listed modules also exist as dependencies
+     *
+     * @throws Exception
+     */
+    public void testGetAjc_moduleArtifacts()
+        throws Exception
+    {
+        ajcCompMojo.javaModules = new Module[2];
+        Module module1 = new Module();
+        String mod1Group = "dill.group";
+        module1.setGroupId( mod1Group );
+        String mod1Artifact = "dall.artifact";
+        module1.setArtifactId( mod1Artifact );
+        ajcCompMojo.javaModules[0] = module1;
+        Module module2 = new Module();
+        String mod2Group = "foooup";
+        module2.setGroupId( mod2Group );
+        String mod2Artifact = "bartifact";
+        module2.setArtifactId( mod2Artifact );
+        ajcCompMojo.javaModules[1] = module2;
+        // Modify project to include depencies
+        Set artifacts = new HashSet();
+        artifacts.add( new MockArtifact( mod1Group, mod1Artifact ) );
+        artifacts.add( new MockArtifact( mod2Group, mod2Artifact ) );
+        ajcCompMojo.project.setArtifacts( artifacts );
+        ajcCompMojo.assembleArguments();
+        List args = ajcCompMojo.ajcOptions;
+        assertTrue( args.contains( "--module-path" ) );
+        Iterator it = args.iterator();
+        while ( !it.next().equals( "--module-path" ) )
+        {
+            // don't do nothing
+        }
+        String modulePath = (String) it.next();
+        assertTrue( modulePath.indexOf( File.pathSeparator ) != -1 );
+        assertTrue( modulePath.indexOf( mod1Artifact ) != -1 );
+        assertTrue( modulePath.indexOf( mod2Artifact ) != -1 );
+    }
+
     // MASPECTJ-103
     public void testGetAJc_EmptyClassifier() throws Exception
     {


### PR DESCRIPTION
This is the simplest initial version of Java 9+ modules support by allowing to specify dependencies as Java modules if they are needed for compilation.

This PR was inspired by StackOverflow question https://stackoverflow.com/q/65286736/1082681.

For now there is no integration test yet, I just verified that it works manually and added simple copy, paste & modify style unit tests.